### PR TITLE
Add MU_DECLARE_CONVERT_ENUM/MU_DEFINE_CONVERT_ENUM/MU_DEFINE_CONVERT_ENUM_WITH_VALIDATION

### DIFF
--- a/inc/azure_macro_utils/macro_utils.h
+++ b/inc/azure_macro_utils/macro_utils.h
@@ -207,14 +207,17 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
         *enum_value_to = (to); \
         return 0; \
 
+#define MU_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO) \
+    MU_C4(convert_enum_, ENUM_TYPE_FROM, _, ENUM_TYPE_TO)
+
 // This macro declares an enum conversion function that translates a value from one enum to another
 #define MU_DECLARE_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO) \
-    int MU_C4(convert_enum_, ENUM_TYPE_FROM, _, ENUM_TYPE_TO)(ENUM_TYPE_FROM enum_value_from, ENUM_TYPE_TO* enum_value_to);
+    int MU_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO)(ENUM_TYPE_FROM enum_value_from, ENUM_TYPE_TO* enum_value_to);
 
 // This macro defines an enum conversion function that translates a value from one enum to another
 // It is implemented as a switch statement. This allows for catching multiple from values being in the list also
 #define MU_DEFINE_CONVERT_ENUM_WITHOUT_INVALID(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
-    int MU_C4(convert_enum_, ENUM_TYPE_FROM, _, ENUM_TYPE_TO)(ENUM_TYPE_FROM enum_value_from, ENUM_TYPE_TO* enum_value_to) \
+    int MU_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO)(ENUM_TYPE_FROM enum_value_from, ENUM_TYPE_TO* enum_value_to) \
     { \
         switch (enum_value_from) \
         { \
@@ -226,19 +229,17 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
     }
 
 // This macro simply adds the conversion of the "well known" by now _INVALID enum value
-#define MU_DEFINE_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
+#define MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
     MU_DEFINE_CONVERT_ENUM_WITHOUT_INVALID(ENUM_TYPE_FROM, ENUM_TYPE_TO, MU_C2(ENUM_TYPE_FROM, _INVALID), MU_C2(ENUM_TYPE_TO, _INVALID), __VA_ARGS__)
 
 #define CONSTRUCT_FROM_FAKE_ENUM(from_value, to_value) \
     MU_C3(fake_from_, from_value, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51),
 
-#define CONSTRUCT_TO_FAKE_ENUM(from_value, to_value) \
-    MU_C3(fake_to_, to_value, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51),
-
 // This macro adds validation of the fact that the from values count in the list match the count of values in the
+// (as opposed to the macro MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION)
 // from enum type. It does that by having a special fake enum where all the "from" values are enumerated
 // The count check is done by having a zero sized array in a struct if the counts do not match
-#define MU_DEFINE_CONVERT_ENUM_WITH_VALIDATION(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
+#define MU_DEFINE_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
     /* Have an enum which has all the "from" values */ \
     /* This enum will have a count */ \
     typedef enum MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_TAG) \
@@ -252,10 +253,7 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
         int MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count_test_array)[((MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count) + 1) == MU_C2(ENUM_TYPE_FROM, _VALUE_COUNT)) ? 1 : 0]; \
         int dummy; \
     } MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_struct); \
-    MU_DEFINE_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO, __VA_ARGS__)
-
-#define MU_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO) \
-    MU_C4(convert_enum_, ENUM_TYPE_FROM, _, ENUM_TYPE_TO)
+    MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION(ENUM_TYPE_FROM, ENUM_TYPE_TO, __VA_ARGS__)
 
 #define MU_DEFINE_STRUCT_FIELD(fieldType, fieldName) fieldType fieldName;
 

--- a/inc/azure_macro_utils/macro_utils.h
+++ b/inc/azure_macro_utils/macro_utils.h
@@ -78,9 +78,13 @@ MU_IF(X, "true", "false") => "true"
 #define MU_EAT_EMPTY_ARG(arg_count, arg) MU_IF(MU_ISEMPTY(arg),,arg) MU_IF(MU_ISEMPTY(arg),MU_EXPAND_TO_NOTHING,MU_IFCOMMALOGIC)(MU_DEC(arg_count))
 #define MU_EAT_EMPTY_ARGS(...) MU_FOR_EACH_1_COUNTED(MU_EAT_EMPTY_ARG, __VA_ARGS__)
 
+#define MU_TYPEDEF_EACH_ENUM_VALUE(enum_value) \
+    typedef int MU_C2(enum_value_typedef_, enum_value);
+
 #define MU_DEFINE_ENUMERATION_CONSTANT(x) x,
 /*MU_DEFINE_ENUM_WITHOUT_INVALID goes to header*/
 #define MU_DEFINE_ENUM_WITHOUT_INVALID(enumName, ...) typedef enum MU_C2(enumName, _TAG) { MU_FOR_EACH_1(MU_DEFINE_ENUMERATION_CONSTANT, __VA_ARGS__) MU_C2(enumName, _VALUE_COUNT) = MU_COUNT_ARG(__VA_ARGS__)} enumName; \
+    MU_FOR_EACH_1(MU_TYPEDEF_EACH_ENUM_VALUE, __VA_ARGS__) \
     extern const char* MU_C2(enumName,Strings)(enumName value); \
     extern int MU_C2(enumName, _FromString)(const char* enumAsString, enumName* destination);
 
@@ -235,6 +239,12 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
 #define CONSTRUCT_FROM_FAKE_ENUM(from_value, to_value) \
     MU_C3(fake_from_, from_value, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51),
 
+// This macro creates a typedef for a from enum value
+// Its type is the enum value of the original enum in order to make sure that only valid
+// enum values are used in from
+#define MU_TYPEDEF_FROM_ENUM_VALUE(from_value, to_value) \
+    typedef MU_C2(enum_value_typedef_, from_value) MU_C2(enum_value_typedef_convert_from_, from_value);
+
 // This macro adds validation of the fact that the from values count in the list match the count of values in the
 // (as opposed to the macro MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION)
 // from enum type. It does that by having a special fake enum where all the "from" values are enumerated
@@ -247,6 +257,7 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
         MU_FOR_EACH_2(CONSTRUCT_FROM_FAKE_ENUM, __VA_ARGS__) \
         MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count) \
     } MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51); \
+    MU_FOR_EACH_2(MU_TYPEDEF_FROM_ENUM_VALUE, __VA_ARGS__) \
     /* "Compare" the count of the from enum values with the count of the values in "ENUM_TYPE_FROM" */ \
     typedef struct MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_struct_TAG) \
     { \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,6 +15,7 @@ set(macro_utils_int_tests_c_files
     mu_define_enum_test.c
     mu_define_local_enum_test.c
     mu_define_enum_2_test.c
+    mu_convert_enum_test.c
     mu_pri_enum_test.c
     main.c
 )
@@ -31,6 +32,7 @@ set(macro_utils_int_tests_h_files
     mu_define_enum_test.h
     mu_define_local_enum_test.h
     mu_define_enum_2_test.h
+    mu_convert_enum_test.h
     mu_pri_enum_test.h
 )
     

--- a/tests/main.c
+++ b/tests/main.c
@@ -11,6 +11,7 @@
 #include "mu_eat_empty_args_test.h"
 #include "mu_count_array_items_test.h"
 #include "mu_define_enum_test.h"
+#include "mu_convert_enum_test.h"
 #include "mu_define_local_enum_test.h"
 #include "mu_define_enum_2_test.h"
 #include "mu_pri_enum_test.h"
@@ -34,6 +35,9 @@ int main(void)
     POOR_MANS_ASSERT(result == 0);
 
     result = run_mu_define_enum_tests();
+    POOR_MANS_ASSERT(result == 0);
+
+    result = run_mu_convert_enum_tests();
     POOR_MANS_ASSERT(result == 0);
 
     result = run_mu_define_local_enum_tests();

--- a/tests/mu_convert_enum_test.c
+++ b/tests/mu_convert_enum_test.c
@@ -21,12 +21,12 @@
 MU_DEFINE_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_FROM_ENUM_VALUES);
 MU_DEFINE_ENUM(TEST_CONVERT_TO_ENUM, TEST_CONVERT_TO_ENUM_VALUES);
 
-/* The following code should not compile :
-MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
+// The following code should not compile because there is a missing test_from_b in the from values :
+/*MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
     test_from_a, test_to_a,
     test_from_c, test_to_b);*/
 
-MU_DEFINE_CONVERT_ENUM_WITH_VALIDATION(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
+MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
     test_from_a, test_to_a,
     test_from_b, test_to_b,
     test_from_c, test_to_b);
@@ -49,6 +49,9 @@ int run_mu_convert_enum_tests(void)
     convert_result = MU_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM)(test_from_c, &result_value);
     POOR_MANS_ASSERT(convert_result == 0);
     POOR_MANS_ASSERT(result_value == test_to_b);
+
+    convert_result = MU_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM)(424242, &result_value);
+    POOR_MANS_ASSERT(convert_result != 0);
 
     return result;
 }

--- a/tests/mu_convert_enum_test.c
+++ b/tests/mu_convert_enum_test.c
@@ -26,6 +26,13 @@ MU_DEFINE_ENUM(TEST_CONVERT_TO_ENUM, TEST_CONVERT_TO_ENUM_VALUES);
     test_from_a, test_to_a,
     test_from_c, test_to_b);*/
 
+// Also the following code should not compile because it uses a from value that is not part of the enum :
+/*MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
+    test_from_a, test_to_a,
+    test_from_b, test_to_a,
+    42, test_to_a,
+    test_from_c, test_to_b);*/
+
 MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
     test_from_a, test_to_a,
     test_from_b, test_to_b,

--- a/tests/mu_convert_enum_test.c
+++ b/tests/mu_convert_enum_test.c
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#include <string.h>
+#include "test_helper.h"
+
+#include "azure_macro_utils/macro_utils.h"
+
+#include "mu_convert_enum_test.h"
+
+// This lists the values in the first enum
+#define TEST_CONVERT_FROM_ENUM_VALUES \
+    test_from_a, \
+    test_from_b, \
+    test_from_c
+
+#define TEST_CONVERT_TO_ENUM_VALUES \
+    test_to_a, \
+    test_to_b
+
+MU_DEFINE_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_FROM_ENUM_VALUES);
+MU_DEFINE_ENUM(TEST_CONVERT_TO_ENUM, TEST_CONVERT_TO_ENUM_VALUES);
+
+/* The following code should not compile :
+MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
+    test_from_a, test_to_a,
+    test_from_c, test_to_b);*/
+
+MU_DEFINE_CONVERT_ENUM_WITH_VALIDATION(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
+    test_from_a, test_to_a,
+    test_from_b, test_to_b,
+    test_from_c, test_to_b);
+
+int run_mu_convert_enum_tests(void)
+{
+    int result = 0;
+
+    TEST_CONVERT_TO_ENUM result_value;
+    int convert_result;
+
+    convert_result = MU_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM)(test_from_a, &result_value);
+    POOR_MANS_ASSERT(convert_result == 0);
+    POOR_MANS_ASSERT(result_value == test_to_a);
+
+    convert_result = MU_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM)(test_from_b, &result_value);
+    POOR_MANS_ASSERT(convert_result == 0);
+    POOR_MANS_ASSERT(result_value == test_to_b);
+
+    convert_result = MU_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM)(test_from_c, &result_value);
+    POOR_MANS_ASSERT(convert_result == 0);
+    POOR_MANS_ASSERT(result_value == test_to_b);
+
+    return result;
+}

--- a/tests/mu_convert_enum_test.h
+++ b/tests/mu_convert_enum_test.h
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+#ifndef MU_CONVERT_ENUM_TEST_H
+#define MU_CONVERT_ENUM_TEST_H
+
+#include "azure_macro_utils/macro_utils.h"
+
+int run_mu_convert_enum_tests(void);
+
+#endif // MU_CONVERT_ENUM_TEST_H


### PR DESCRIPTION
One would like to have a declare/define macro pair to generate some conversion between enums, since many layers in our project convert between enums.