### PR TITLE
Fix detection of using enum values that are not part of the enum

### DIFF
--- a/inc/azure_macro_utils/macro_utils.h
+++ b/inc/azure_macro_utils/macro_utils.h
@@ -69,7 +69,6 @@ MU_IF(X, "true", "false") => "true"
 #define MU_IF0(trueBranch, falseBranch) falseBranch
 #define MU_IF1(trueBranch, falseBranch) trueBranch
 
-
 /*the following macro want to eat empty arguments from a list */
 /*examples:                                                   */
 /*MU_EAT_EMPTY_ARGS(, , X) expands to X                       */
@@ -78,13 +77,12 @@ MU_IF(X, "true", "false") => "true"
 #define MU_EAT_EMPTY_ARG(arg_count, arg) MU_IF(MU_ISEMPTY(arg),,arg) MU_IF(MU_ISEMPTY(arg),MU_EXPAND_TO_NOTHING,MU_IFCOMMALOGIC)(MU_DEC(arg_count))
 #define MU_EAT_EMPTY_ARGS(...) MU_FOR_EACH_1_COUNTED(MU_EAT_EMPTY_ARG, __VA_ARGS__)
 
-#define MU_TYPEDEF_EACH_ENUM_VALUE(enum_value) \
-    typedef int MU_C2(enum_value_typedef_, enum_value);
-
 #define MU_DEFINE_ENUMERATION_CONSTANT(x) x,
+#define MU_DEFINE_METADATA_ENUMERATION_VALUE(x) MU_C2(enum_value_typedef_, x),
+
 /*MU_DEFINE_ENUM_WITHOUT_INVALID goes to header*/
-#define MU_DEFINE_ENUM_WITHOUT_INVALID(enumName, ...) typedef enum MU_C2(enumName, _TAG) { MU_FOR_EACH_1(MU_DEFINE_ENUMERATION_CONSTANT, __VA_ARGS__) MU_C2(enumName, _VALUE_COUNT) = MU_COUNT_ARG(__VA_ARGS__)} enumName; \
-    MU_FOR_EACH_1(MU_TYPEDEF_EACH_ENUM_VALUE, __VA_ARGS__) \
+#define MU_DEFINE_ENUM_WITHOUT_INVALID(enumName, ...) typedef enum MU_C2(enumName, _TAG) { MU_FOR_EACH_1(MU_DEFINE_ENUMERATION_CONSTANT, __VA_ARGS__)} enumName; \
+    typedef enum MU_C3(enum_value_metadata_, enumName, _TAG) { MU_FOR_EACH_1(MU_DEFINE_METADATA_ENUMERATION_VALUE, __VA_ARGS__) MU_C3(enum_value_metadata_, enumName, _VALUE_COUNT) = MU_COUNT_ARG(__VA_ARGS__)} MU_C2(enum_value_metadata_, enumName); \
     extern const char* MU_C2(enumName,Strings)(enumName value); \
     extern int MU_C2(enumName, _FromString)(const char* enumAsString, enumName* destination);
 
@@ -239,17 +237,25 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
 #define CONSTRUCT_FROM_FAKE_ENUM(from_value, to_value) \
     MU_C3(fake_from_, from_value, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51),
 
+#define CONSTRUCT_FIELD_FROM_FAKE_ENUM(from_value, to_value) \
+    int MU_C3(fake_from_, from_value, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51)[(MU_C2(enum_value_typedef_, from_value) == MU_C2(enum_value_typedef_, from_value)) ? 1 : 0];
+
 // This macro creates a typedef for a from enum value
 // Its type is the enum value of the original enum in order to make sure that only valid
 // enum values are used in from
 #define MU_TYPEDEF_FROM_ENUM_VALUE(from_value, to_value) \
-    typedef MU_C2(enum_value_typedef_, from_value) MU_C2(enum_value_typedef_convert_from_, from_value);
+    MU_C2(enum_value_typedef_convert_from_, from_value);
 
 // This macro adds validation of the fact that the from values count in the list match the count of values in the
 // (as opposed to the macro MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION)
 // from enum type. It does that by having a special fake enum where all the "from" values are enumerated
 // The count check is done by having a zero sized array in a struct if the counts do not match
 #define MU_DEFINE_CONVERT_ENUM(ENUM_TYPE_FROM, ENUM_TYPE_TO, ...) \
+    /* This forces matching the values in from to enum values generated with MU_DEFINE_ENUM */ \
+    typedef struct MU_C3(fake_check_enum_values_exist_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_TAG) \
+    { \
+        MU_FOR_EACH_2(CONSTRUCT_FIELD_FROM_FAKE_ENUM, __VA_ARGS__) \
+    } MU_C3(fake_check_enum_values_exist_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51); \
     /* Have an enum which has all the "from" values */ \
     /* This enum will have a count */ \
     typedef enum MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_TAG) \
@@ -261,7 +267,7 @@ const char* MU_C3(MU_, enumIdentifier,_ToString)(enumIdentifier value)          
     /* "Compare" the count of the from enum values with the count of the values in "ENUM_TYPE_FROM" */ \
     typedef struct MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_struct_TAG) \
     { \
-        int MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count_test_array)[((MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count) + 1) == MU_C2(ENUM_TYPE_FROM, _VALUE_COUNT)) ? 1 : 0]; \
+        int MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count_test_array)[((MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_count) + 1) == MU_C3(enum_value_metadata_, ENUM_TYPE_FROM, _VALUE_COUNT)) ? 1 : 0]; \
         int dummy; \
     } MU_C3(fake_, ENUM_TYPE_FROM, _C0FB3709_EDE8_4288_8F70_FDDB5D8D7A51_struct); \
     MU_DEFINE_CONVERT_ENUM_WITHOUT_VALIDATION(ENUM_TYPE_FROM, ENUM_TYPE_TO, __VA_ARGS__)

--- a/tests/mu_convert_enum_test.c
+++ b/tests/mu_convert_enum_test.c
@@ -11,7 +11,7 @@
 // This lists the values in the first enum
 #define TEST_CONVERT_FROM_ENUM_VALUES \
     test_from_a, \
-    test_from_b, \
+    test_from_b = 42, /* Assigning a value to the enum used to fail ..., now fixed */ \
     test_from_c
 
 #define TEST_CONVERT_TO_ENUM_VALUES \
@@ -29,7 +29,6 @@ MU_DEFINE_ENUM(TEST_CONVERT_TO_ENUM, TEST_CONVERT_TO_ENUM_VALUES);
 // Also the following code should not compile because it uses a from value that is not part of the enum :
 /*MU_DEFINE_CONVERT_ENUM(TEST_CONVERT_FROM_ENUM, TEST_CONVERT_TO_ENUM,
     test_from_a, test_to_a,
-    test_from_b, test_to_a,
     42, test_to_a,
     test_from_c, test_to_b);*/
 


### PR DESCRIPTION
Fix detection of using enum values that are not part of the enum